### PR TITLE
Enable notification of past events

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -12,3 +12,4 @@ nickname = Indico Bot
 image_url = https://avatars.githubusercontent.com/u/715236?s=200
 channels = announcements
 categories = 1234,5678,91011
+time_delta = 30m

--- a/indico_mattermost_bot.py
+++ b/indico_mattermost_bot.py
@@ -2,15 +2,36 @@ import click
 import hashlib
 import hmac
 import json
+import re
 import requests
 import time
 from configparser import ConfigParser
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from pytz import timezone, utc
 from urllib.parse import urlencode, urljoin
 
 
 notified = set()
+
+
+def _parse_time_delta(time_delta):
+    """
+    Parse string and return a timedelta.
+
+    Accepted formats:
+
+     * days in the future/past: '[+/-]DdHHhMMm'
+    """
+    m = re.match(r'^([+-])?(?:(\d{1,3})d)?(?:(\d{1,2})h)?(?:(\d{1,2})m)?$', time_delta)
+    if m:
+        mod = -1 if m.group(1) == '-' else 1
+
+        atoms = list(0 if a is None else int(a) * mod for a in m.groups()[1:])
+        if atoms[1] > 23 or atoms[2] > 59:
+            raise Exception("Invalid time!")
+        return timedelta(days=atoms[0], hours=atoms[1], minutes=atoms[2])
+    else:
+        raise Exception("Wrong format for timedelta: %s" % time_delta)
 
 
 def _dt(dt_dict):
@@ -26,7 +47,9 @@ def _split(text):
 def _process_bots(config):
     channel_ids = [section for section in config.sections() if section.startswith('channel_')]
     bot_ids = [section for section in config.sections() if section.startswith('bot_')]
-    channel_hooks = {cid[8:]: {'hook_url': config[cid]['hook_url'], 'text': config[cid]['text']} for cid in channel_ids}
+    channel_hooks = {cid[8:]: {'hook_url': config[cid]['hook_url'],
+                               'text': config[cid]['text']}
+                     for cid in channel_ids}
     bots = {}
 
     for bid in bot_ids:
@@ -36,7 +59,8 @@ def _process_bots(config):
             'image_url': bot_data['image_url'],
             'categories': _split(bot_data['categories']),
             'nickname': bot_data['nickname'],
-            'channels': _split(bot_data['channels'])
+            'channels': _split(bot_data['channels']),
+            'timedelta': bot_data['timedelta']
         }
         bots[bid[4:]] = bot
 
@@ -79,6 +103,10 @@ def read_config(config_file):
     }
 
 
+def _is_fetching_past_events(bot):
+    return bot['timedelta'].startswith('-')
+
+
 def check_upcoming(config, verbose):
     global notified
 
@@ -86,22 +114,29 @@ def check_upcoming(config, verbose):
 
     bots, channels = config['bots'], config['channels']
     for bot in bots.values():
-        url = urljoin(config['server_url'], 'export/categ/{}.json'.format('-'.join(bot['categories'])))
+        url_path = 'export/categ/{}.json'.format('-'.join(bot['categories']))
         params = {
             'from': 'now',
-            'to': '+30m',
-            'limit': 100
+            'to': bot['timedelta'],
+            'limit': '100'
         }
+        if _is_fetching_past_events(bot):
+            time_delta = _parse_time_delta(bot['timedelta'])
+            from_date = now + time_delta
+            params['from'] = (from_date - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M")
+            params['to'] = from_date.strftime("%Y-%m-%dT%H:%M")
+            params['tz'] = 'UTC'
+
         if config['api_key']:
-            params['api_key'] = config['api_key']
+            params['apikey'] = config['api_key']
             if config['secret']:
                 params['timestamp'] = str(int(time.time()))
                 items = sorted(params.items(), key=lambda x: x[0].lower())
-                param_url = '{}?{}'.format(url, urlencode(items)).encode('utf-8')
+                param_url = '/{}?{}'.format(url_path, urlencode(items)).encode('utf-8')
                 params['signature'] = hmac.new(config['secret'].encode('utf-8'), param_url, hashlib.sha1).hexdigest()
 
         qstring = urlencode(params)
-        url = '{}?{}'.format(url, qstring)
+        url = '{}?{}'.format(urljoin(config['server_url'], url_path), qstring)
         if verbose:
             print('[d] URL: {}'.format(url))
         req = requests.get(url)
@@ -113,7 +148,7 @@ def check_upcoming(config, verbose):
         for event in results:
             evt_id = event['id']
             start_dt = _dt(event['startDate'])
-            if now > (start_dt - timedelta(minutes=15)) and start_dt > now and evt_id not in notified:
+            if (_is_fetching_past_events(bot) or start_dt > now) and evt_id not in notified:
                 notify(event, bot, channels)
                 if verbose:
                     print('[>] Notified {} about {}'.format(bot['channels'], event['id']))


### PR DESCRIPTION
- Added 'timedelta' to the configuration file so we can specify
  the timespan (e.g. 30m). If negative (e.g. -3h), events from the past
  will be fetched and notified.
